### PR TITLE
Add delays and expiration date for Facebook photos downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ The Sink update command is invoked by the following command
 * `-s SCORE, --score SCORE` - score threshold to automatically link contacts.  Must be between 0 and 100.  The higher this number, the more similar contact and friends names must be to be automatically linked.  Defaults to 100 (perfect match).
 * `-m MATCHES, --matches MATCHES` - the number of results to show when searching for friends to link to a contact.  Defaults to 5.
 * `-r RETRIES, --retries RETRIES` - number of times to retry updating photos before failing.  Defaults to 3.
-* `-d DELAY, --delay DELAY` - seconds to wait between photo updates to avoid being blocked from facebook. Default to 5.
+* `-d DELAY, --delay DELAY` - seconds to wait between photo updates to avoid being blocked from facebook.  Default to 5.
+* `-e EXPIRY, --expiry EXPIRY` - number of days a photo is valid, the photo is updated if expired, mitigate blockade from facebook.  Default to 30.
+
 To view information about the Sink update command invoke help
 
     $ python sink.py update -h
@@ -85,7 +87,7 @@ To view information about the Sink delete command invoke help
 
 #### Facebook
 
-Sink scrapes your Facebook profile friends page to obtain a list of your friends' names and their Facebook usernames.  These usernames are then used to scrape your friends' profile pages to obtain their user ID.  This ID is then used to query the [Facebook Graph API](https://developers.facebook.com/docs/graph-api) (specifically [User Picture](https://developers.facebook.com/docs/graph-api/reference/user/picture)) to obtain their profile picture.
+Sink scrapes your Facebook profile friends page to obtain a list of your friends' names and their Facebook usernames.  These usernames are then used to scrape your friends' profile pages to obtain their user ID.  This ID is then used to query the [Facebook Graph API](https://developers.facebook.com/docs/graph-api) (specifically [User Picture](https://developers.facebook.com/docs/graph-api/reference/user/picture)) to obtain their profile picture. Sink limits the number of requests made to facebook not to be blocked.
 
 #### Google Contacts
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The update command updates your links and contact photos.  This command first cr
 
 The Sink update command is invoked by the following command
 
-    $ python sink.py update [filename] [-a] [-i] [-s SCORE] [-m MATCHES] [-r RETRIES]
+    $ python sink.py update [filename] [-a] [-i] [-s SCORE] [-m MATCHES] [-r RETRIES] [-d DELAY]
 
 ###### Optional Arguments
 
@@ -40,7 +40,7 @@ The Sink update command is invoked by the following command
 * `-s SCORE, --score SCORE` - score threshold to automatically link contacts.  Must be between 0 and 100.  The higher this number, the more similar contact and friends names must be to be automatically linked.  Defaults to 100 (perfect match).
 * `-m MATCHES, --matches MATCHES` - the number of results to show when searching for friends to link to a contact.  Defaults to 5.
 * `-r RETRIES, --retries RETRIES` - number of times to retry updating photos before failing.  Defaults to 3.
-
+* `-d DELAY, --delay DELAY` - seconds to wait between photo updates to avoid being blocked from facebook. Default to 5.
 To view information about the Sink update command invoke help
 
     $ python sink.py update -h

--- a/sink.py
+++ b/sink.py
@@ -61,6 +61,13 @@ You will be presented with a prompt. There are three options.\n\
      This is helpful if a contact's name does not closely match their Facebook name.\n\
   3. Press Enter without typing anything to ignore the contact.\n\
      Sink will ignore this contact during updates.'''
+BLOCKED_MESSAGES = [
+    "You’re Temporarily Blocked",
+    "Se te bloqueó temporalmente",
+    "Vous êtes temporairement bloqué",
+    "Du wurdest vorrübergehend blockiert",
+    "O teu acesso está bloqueado temporariamente",
+    "Ti hanno bloccato temporaneamente"]
 
 # Default arguments
 PORT = 7465
@@ -167,8 +174,7 @@ class Facebook:
 
     def get_profile_picture(self, friend_url, friend):
         profile_response = self.browser.open(self.base_url + friend_url)
-        blocked = "<title>Vous êtes temporairement bloqué</title>"
-        if blocked in profile_response.text:
+        if profile_response.soup.title.text in BLOCKED_MESSAGES:
             print("BLOCKED! Retry later...")
             exit(-1)
         user_id = re.search(self.user_id_regex, profile_response.text).group(1)

--- a/sink.py
+++ b/sink.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import time
@@ -65,7 +66,7 @@ PORT = 7465
 SCORE_THRESHOLD = 100
 MATCH_LIMIT = 5
 RETRIES = 3
-DELAY = 3
+DELAY = 5
 
 # Shelf keys
 TOKEN = 'token'
@@ -298,7 +299,6 @@ class Sink:
                     self._set_checksum(contact_url, checksum)
                 else:
                     print("FAILED: " + self.contacts[contact_url])
-            # add delay between requests not to be blocked by facebook
             time.sleep(delay)
 
     def _delete_photos(self, retries):
@@ -418,7 +418,7 @@ def main():
     shelf = shelve.open(args.filename)
     sink = Sink(shelf)
     if args.command == 'update':
-        sink.update(args.update_ignored, args.auto_only, args.score_threshold, args.match_limit, args.retries)
+        sink.update(args.update_ignored, args.auto_only, args.score_threshold, args.match_limit, args.retries, args.delay)
     elif args.command == 'edit':
         sink.edit(args.score_threshold, args.match_limit)
     elif args.command == 'delete':
@@ -439,7 +439,9 @@ def parse_args():
     param_parser.add_argument('-m', '--matches', dest='match_limit', metavar='MATCHES', default=MATCH_LIMIT, type=int, help='number of matches to show when searching contacts')
     retry_parser = argparse.ArgumentParser(add_help=False)
     retry_parser.add_argument('-r', '--retries', dest='retries', metavar='RETRIES', default=RETRIES, type=int, help='number of times to retry updating photos before failing')
-    update = subparsers.add_parser('update', parents=[file_parser, update_parser, param_parser, retry_parser], description=UDPATE_DESCRIPTION, help='update contact photos', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    delay_parser = argparse.ArgumentParser(add_help=False)
+    delay_parser.add_argument('-d', '--delay', dest='delay', metavar='DELAY', default=DELAY, type=int, help='seconds to wait between photo updates, avoid being blocked from facebook')
+    update = subparsers.add_parser('update', parents=[file_parser, update_parser, param_parser, retry_parser, delay_parser], description=UDPATE_DESCRIPTION, help='update contact photos', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     edit = subparsers.add_parser('edit', parents=[file_parser, param_parser], description=EDIT_DESCRIPTION, help='edit contact links', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     delete = subparsers.add_parser('delete', parents=[file_parser, delete_parser, retry_parser], description=DELETE_DESCRIPTION, help='delete contact photos', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     return parser.parse_args()

--- a/sink.py
+++ b/sink.py
@@ -304,9 +304,9 @@ class Sink:
                         self._set_checksum(contact_url, checksum)
                     else:
                         print("FAILED: " + self.contacts[contact_url])
+                time.sleep(delay)
             else:
                 print("NOT EXPIRED: " + self.contacts[contact_url])
-            time.sleep(delay)
 
     def _delete_photos(self, retries):
         print("Deleting photos...")


### PR DESCRIPTION
Facebook blocks Sink if it generates too many requests. Therefore mitigation are needed.
Here are two of them : delay between two requests and expiration date of pictures.

The delay makes Sink work slower so it is less prone to trigger the blocking by Facebook. If the blockade is on, Sink detects it (in several languages) and stops. It will work again as soon as it is not blocked anymore. It has to be relaunch manually.

The expiry date allows Sink not to re-request Facebook for the same friends' photo when it is launched several times (especially when you are blocked by Facebook, you want to relaunch sink several times to get all the photos). When the photo is requested, the date of today is associated to the photo. Sink checks the date of the last update before requesting Facebook, if the date is anterior to 30 days from today it updates the photo, else it passes to the next contact. 

Those two parameters are configurable from command line.